### PR TITLE
Recognise more modes

### DIFF
--- a/apps/vim/vim.py
+++ b/apps/vim/vim.py
@@ -1054,13 +1054,13 @@ class VimMode:
             print(s)
 
     def is_normal_mode(self):
-        return self.current_mode == "n"
+        return self.current_mode in ["n", "niI"]
 
     def is_visual_mode(self):
         return self.current_mode in ["v", "V", "^V"]
 
     def is_insert_mode(self):
-        return self.current_mode == "i"
+        return self.current_mode in ["i", "ic"]
 
     def is_terminal_mode(self):
         return self.current_mode == "t"


### PR DESCRIPTION
Recognize "insert normal" and "insert completion" modes. Without insert competition, vim would sometimes think it is in normal mode even though it is in insert mode (tested with youcompleteme) and emit an i. I suspect I added the inside normal mode after it triggered some of my asserts and not because of some functional thing, but adding it shouldn't hurt anyway. 