### PR TITLE
vim: Fix heading tags in surround targets

### DIFF
--- a/apps/vim/vim.py
+++ b/apps/vim/vim.py
@@ -460,8 +460,8 @@ ctx.lists["self.vim_surround_targets"] = {
     "paragraph": "p",
     "spaces": "  ",  # double spaces is required because surround gets confused
     "tags": "t",
-    "h1 tags": "<h1>",
-    "h2 tags": "<h2>",
+    "H one tags": "<h1>",
+    "H two tags": "<h2>",
     "div tags": "<div>",
     "bold tags": "<b>",
 }


### PR DESCRIPTION
Fixes the following warning from Talon:

    WARNING list 'user.vim_surround_targets' skipped unknown tokens: ['1', '2']